### PR TITLE
Include cause in stack trace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
+.settings
+.project
+.classpath
 logback-gelf-appender.iml
 target

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
         <connection>scm:git:git@github.com:rkcpi/logback-gelf-appender.git</connection>
         <developerConnection>scm:git:git@github.com:rkcpi/logback-gelf-appender.git</developerConnection>
         <url>https://github.com/rkcpi/logback-gelf-appender</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <distributionManagement>
         <snapshotRepository>

--- a/src/test/java/de/appelgriepsch/logback/GelfAppenderTest.java
+++ b/src/test/java/de/appelgriepsch/logback/GelfAppenderTest.java
@@ -1,13 +1,10 @@
 package de.appelgriepsch.logback;
 
 import org.junit.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
-
-import static org.junit.Assert.*;
 
 
 /**
@@ -39,6 +36,25 @@ public class GelfAppenderTest {
 
         try {
             throw new Exception("Test");
+        } catch (Exception e) {
+            e.fillInStackTrace();
+            logger.error("hello", e);
+        }
+    }
+
+    @Test
+    public void testExceptionWithCause() {
+
+        final Logger logger = LoggerFactory.getLogger("test");
+
+        try {
+           try {
+              throw new Exception("Test");
+           }
+           catch (Exception e)
+           {
+              throw new Exception (e);
+           }
         } catch (Exception e) {
             e.fillInStackTrace();
             logger.error("hello", e);


### PR DESCRIPTION
When using this appender I ran into an issue where the "cause" Exceptions were not printed, which made it quite hard for me to see what was really going on.

I reviewed the code and saw that it builds the stack trace manually, not recursing to get the cause. I looked around how logback handles this and found the `ThrowableProxyConverter`, which is actually designed to pretty print stack traces. So I replaced the original code with a call to this converter.

I also added a test case for this and incremented the version number.