### PR TITLE
Add possibility to add a additional field one by one

### DIFF
--- a/src/main/java/de/appelgriepsch/logback/GelfAppender.java
+++ b/src/main/java/de/appelgriepsch/logback/GelfAppender.java
@@ -294,6 +294,15 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
     }
 
 
+    public void addAdditionalField(String key, String value) {
+
+        try {
+            this.additionalFields.put(key, value);
+        } catch (Exception e) {
+            addWarn("Failed to add additional field: " + e.getMessage(), e);
+        }
+    }
+
     public void setLayout(Layout<ILoggingEvent> layout) {
 
         this.layout = layout;


### PR DESCRIPTION
In a programmatically created gelf appender it is much easier to add the additional fields one by one instead to create a string with all information and then again split it up in gelf appender. For xml based configuration it would be nice to have the complete string via setAdditionalFields(String ...)