### PR TITLE
Set default layout when context is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The appender has several configurable properties:
   * Whether Nagle's algorithm should be used for TCP connections
 * `tcpKeepAlive` (default: `false`)
   * Whether to try keeping alive TCP connections.
-* `layout` (default: `"%m"`)
+* `layout` (default: `"%m %n"`)
   * The [Layout](http://logback.qos.ch/manual/layouts.html) to use to format the LogEvent; the resulting string will be used as GELF's `short_message` (exception stacktraces are not included in this message)
 * `additionalFields`
   * Comma-delimited list of key=value pairs to be included in every message

--- a/src/main/java/de/appelgriepsch/logback/GelfAppender.java
+++ b/src/main/java/de/appelgriepsch/logback/GelfAppender.java
@@ -1,6 +1,6 @@
 package de.appelgriepsch.logback;
 
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
@@ -50,17 +50,6 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
     private Layout<ILoggingEvent> layout;
 
     private GelfTransport client;
-
-    public GelfAppender() {
-
-        super();
-
-        PatternLayoutEncoder patternLayoutEncoder = new PatternLayoutEncoder();
-        patternLayoutEncoder.setPattern("%m %n");
-
-        Layout<ILoggingEvent> layout = patternLayoutEncoder.getLayout();
-        this.layout = layout;
-    }
 
     @Override
     protected void append(ILoggingEvent event) {
@@ -134,10 +123,16 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
 
     @Override
     public void start() {
-
-        super.start();
+        if (this.layout == null) {
+            PatternLayout patternLayout = new PatternLayout();
+            patternLayout.setContext(context);
+            patternLayout.setPattern("%m %n");
+            patternLayout.start();
+            this.layout = patternLayout;
+        }
         createGelfClient();
         throwableConverter.start();
+        super.start();
     }
 
 


### PR DESCRIPTION
This fixes serious bug - a `NullPointerException` is thrown if custom `layout` is not set.

The reason is that this original code from constructor assigns `null` to `this.layout`:
```java
PatternLayoutEncoder patternLayoutEncoder = new PatternLayoutEncoder();
patternLayoutEncoder.setPattern("%m %n");
Layout<ILoggingEvent> layout = patternLayoutEncoder.getLayout();
this.layout = layout;
```

To overcome this issue, we must call `patternLayoutEncoder.start()` method. To call this method correctly, `context` must be set before. It's the reason why I moved this code from constructor to `start` method (where `context` is available).

I also used `PatternLayout` directly because `PatternLayoutEncoder` adds nothing.