### PR TITLE
Handle when caller data is empty array

### DIFF
--- a/src/main/java/de/appelgriepsch/logback/GelfAppender.java
+++ b/src/main/java/de/appelgriepsch/logback/GelfAppender.java
@@ -84,7 +84,7 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
 
         StackTraceElement[] callerData = event.getCallerData();
 
-        if (includeSource && event.hasCallerData()) {
+        if (includeSource && event.hasCallerData() && callerData.length > 0) {
             StackTraceElement source = callerData[0];
 
             builder.additionalField("sourceFileName", source.getFileName());


### PR DESCRIPTION
Some implementation of `ILoggingEvent` can return empty array (it's happening for us) so we should handle this situation.

```
ERROR in de.appelgriepsch.logback.GelfAppender[GRAYLOG] - Appender [GRAYLOG] failed to append. java.lang.ArrayIndexOutOfBoundsException: 0
	at java.lang.ArrayIndexOutOfBoundsException: 0
	at 	at de.appelgriepsch.logback.GelfAppender.append(GelfAppender.java:88)
	at 	at de.appelgriepsch.logback.GelfAppender.append(GelfAppender.java:32)
	at 	at ch.qos.logback.core.AppenderBase.doAppend(AppenderBase.java:82)
	at 	at ch.qos.logback.core.spi.AppenderAttachableImpl.appendLoopOnAppenders(AppenderAttachableImpl.java:48)
	at 	at ch.qos.logback.core.AsyncAppenderBase$Worker.run(AsyncAppenderBase.java:265)
```