### PR TITLE
Fixed copy of event to be passed to formatting layout. Needed fields were not copied.

### DIFF
--- a/src/main/java/de/appelgriepsch/logback/GelfAppender.java
+++ b/src/main/java/de/appelgriepsch/logback/GelfAppender.java
@@ -63,6 +63,10 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
         copy.setMessage(event.getMessage());
         copy.setLevel(event.getLevel());
         copy.setArgumentArray(event.getArgumentArray());
+        copy.setLoggerName(event.getLoggerName());
+        copy.setThreadName(event.getThreadName());
+        copy.setTimeStamp(event.getTimeStamp());
+        copy.setMDCPropertyMap(copy.getMDCPropertyMap());
 
         final GelfMessageBuilder builder = new GelfMessageBuilder(this.layout.doLayout(copy), hostName()).timestamp(
                     event.getTimeStamp() / 1000d)

--- a/src/main/java/de/appelgriepsch/logback/GelfAppender.java
+++ b/src/main/java/de/appelgriepsch/logback/GelfAppender.java
@@ -66,7 +66,7 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
         copy.setLoggerName(event.getLoggerName());
         copy.setThreadName(event.getThreadName());
         copy.setTimeStamp(event.getTimeStamp());
-        copy.setMDCPropertyMap(copy.getMDCPropertyMap());
+        copy.setMDCPropertyMap(event.getMDCPropertyMap());
 
         final GelfMessageBuilder builder = new GelfMessageBuilder(this.layout.doLayout(copy), hostName()).timestamp(
                     event.getTimeStamp() / 1000d)


### PR DESCRIPTION
Not sure what was the reason to not copy some of the fields (excl. the stack trace related). I'm needing them for the pattern logging. Maybe you will consider good idea having them?